### PR TITLE
Fixes in `gmatch` implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,4 +4,4 @@ version = 4
 
 [[package]]
 name = "lsonar"
-version = "0.2.2"
+version = "0.2.3"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,4 +4,4 @@ version = 4
 
 [[package]]
 name = "lsonar"
-version = "0.2.1"
+version = "0.2.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lsonar"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2024"
 authors = ["reloginn <nikita.malina23@gmail.com>"]
 description = "Lua 5.3 pattern engine, fully compatible with the original Lua 5.3 engine"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lsonar"
-version = "0.2.2"
+version = "0.2.3"
 edition = "2024"
 authors = ["reloginn <nikita.malina23@gmail.com>"]
 description = "Lua 5.3 pattern engine, fully compatible with the original Lua 5.3 engine"

--- a/src/lua/gmatch.rs
+++ b/src/lua/gmatch.rs
@@ -5,10 +5,10 @@ mod iter;
 pub use iter::GMatchIterator;
 
 /// Corresponds to Lua 5.3 `string.gmatch`
-pub fn gmatch<'a>(
-    text: &'a str,
+pub fn gmatch(
+    text: &str,
     pattern: &str,
-) -> Result<impl Iterator<Item = Result<Vec<String>>> + 'a> {
+) -> Result<GMatchIterator> {
     let is_empty_pattern = pattern.is_empty();
 
     let pattern_ast = if is_empty_pattern {

--- a/src/lua/gmatch.rs
+++ b/src/lua/gmatch.rs
@@ -19,7 +19,7 @@ pub fn gmatch<'a>(
     };
 
     Ok(GMatchIterator {
-        text: text.as_bytes(),
+        bytes: text.as_bytes().to_vec(),
         pattern_ast,
         current_pos: 0,
         is_empty_pattern,

--- a/src/lua/gmatch/iter.rs
+++ b/src/lua/gmatch/iter.rs
@@ -1,17 +1,17 @@
 use crate::{AstNode, Result, engine::find_first_match};
 
-pub struct GMatchIterator<'a> {
-    pub(super) text: &'a [u8],
+pub struct GMatchIterator {
+    pub(super) bytes: Vec<u8>,
     pub(super) pattern_ast: Vec<AstNode>,
     pub(super) current_pos: usize,
     pub(super) is_empty_pattern: bool,
 }
 
-impl Iterator for GMatchIterator<'_> {
+impl Iterator for GMatchIterator {
     type Item = Result<Vec<String>>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        if self.current_pos > self.text.len() {
+        if self.current_pos > self.bytes.len() {
             return None;
         }
 
@@ -23,11 +23,11 @@ impl Iterator for GMatchIterator<'_> {
             return result;
         }
 
-        match find_first_match(&self.pattern_ast, self.text, self.current_pos) {
+        match find_first_match(&self.pattern_ast, &self.bytes, self.current_pos) {
             Ok(Some((match_range, captures))) => {
                 if match_range.start == match_range.end {
                     self.current_pos = match_range.end + 1;
-                    if self.current_pos > self.text.len() {
+                    if self.current_pos > self.bytes.len() {
                         return None;
                     }
                 } else {
@@ -39,13 +39,13 @@ impl Iterator for GMatchIterator<'_> {
                         .into_iter()
                         .filter_map(|maybe_range| {
                             maybe_range.map(|range| {
-                                String::from_utf8_lossy(&self.text[range]).into_owned()
+                                String::from_utf8_lossy(&self.bytes[range]).into_owned()
                             })
                         })
                         .collect()
                 } else {
                     vec![
-                        String::from_utf8_lossy(&self.text[match_range.start..match_range.end])
+                        String::from_utf8_lossy(&self.bytes[match_range.start..match_range.end])
                             .into_owned(),
                     ]
                 };


### PR DESCRIPTION
# Fixes:
- Removed the `'a` lifetime from [`GMatchIterator`], `text` was renamed to `bytes`, and the type was changed to [`Vec<u8>`].
- `gmatch` now returns `GMatchIterator` instead of `impl Iterator`.