### PR TITLE
Add repository to Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 authors = ["reloginn <nikita.malina23@gmail.com>"]
 description = "Lua 5.3 pattern engine, fully compatible with the original Lua 5.3 engine"
 license = "MIT"
+repository = "https://github.com/reloginn/lsonar"
 
 [dependencies]
 


### PR DESCRIPTION
Without repository in Cargo.toml it is hard to find the upstream for the crate.