### PR TITLE
Implement inverted character class

### DIFF
--- a/tests/match.rs
+++ b/tests/match.rs
@@ -27,6 +27,14 @@ fn test_pattern_classes() {
         r#match("abc123", "%d+", None),
         Ok(Some(convert_to_string_vec(&["123"])))
     );
+    assert_eq!(
+        r#match("abc123", "[%D]+", None),
+        Ok(Some(convert_to_string_vec(&["abc"])))
+    );
+    assert_eq!(
+        r#match("abc123", "[%A]+", None),
+        Ok(Some(convert_to_string_vec(&["123"])))
+    );
 }
 
 #[test]


### PR DESCRIPTION
PIL 20.2: An upper case version of any of those classes represents the complement of the class.

The complements were in the test suite for bare pattern but not for character set, where they were failing. This patch adds a basic test for complement class in a character set.

The implementation looks a little weird. The list of bytes is an ordered list of transition points, not ranges, and the simple inversion trick requires exclusive end indexes. There might be a cleaner and equally or more efficient way to do this but I am a smooth brain.